### PR TITLE
Expand cache key variants

### DIFF
--- a/ck/internal/constant/constant.go
+++ b/ck/internal/constant/constant.go
@@ -23,16 +23,9 @@ const (
 
 // Default values
 const (
-	DefaultAttackerDomain  = "attacker.example"
+	DefaultExampleDomain   = "example.com"
 	DefaultProto           = "http"
 	DefaultForwardedPrefix = "host="
-)
-
-// Human-readable variant names
-const (
-	NameXForwardedHost  = "X-Forwarded-Host: attacker.example"
-	NameForwarded       = "Forwarded: host=attacker.example"
-	NameXForwardedProto = "X-Forwarded-Proto: http"
 )
 
 const (

--- a/ck/internal/scan/variants.go
+++ b/ck/internal/scan/variants.go
@@ -1,38 +1,71 @@
 package scan
 
 import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
 	constants "github.com/selimozcann/cachekeyhunter/ck/internal/constant"
 	"github.com/selimozcann/cachekeyhunter/ck/internal/types"
 )
 
 func GenerateVariants() []types.Variant {
-	return []types.Variant{
-		{
-			Name: "X-Forwarded-Host: attacker.example",
+	var variants []types.Variant
+
+	headers, _ := loadLines("wordlists/headers.txt")
+	for _, h := range headers {
+		variants = append(variants, types.Variant{
+			Name:    fmt.Sprintf("%s: %s", h, constants.DefaultExampleDomain),
+			Headers: map[string]string{h: constants.DefaultExampleDomain},
+		})
+	}
+
+	params, _ := loadLines("wordlists/params.txt")
+	for _, p := range params {
+		parts := strings.SplitN(p, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, val := parts[0], parts[1]
+		variants = append(variants, types.Variant{
+			Name:  fmt.Sprintf("Query %s=%s", key, val),
+			Query: map[string]string{key: val},
+		})
+	}
+
+	variants = append(variants,
+		types.Variant{
+			Name: fmt.Sprintf("%s: host=%s", constants.HeaderForwarded, constants.DefaultExampleDomain),
 			Headers: map[string]string{
-				constants.HeaderXForwardedHost: constants.DefaultAttackerDomain,
+				constants.HeaderForwarded: constants.DefaultForwardedPrefix + constants.DefaultExampleDomain,
 			},
 		},
-		{
-			Name: "Forwarded: host=attacker.example",
-			Headers: map[string]string{
-				constants.HeaderForwarded: constants.DefaultForwardedPrefix + constants.DefaultAttackerDomain,
-			},
-		},
-		{
-			Name: "X-Forwarded-Proto: http",
+		types.Variant{
+			Name: fmt.Sprintf("%s: %s", constants.HeaderXForwardedProto, constants.DefaultProto),
 			Headers: map[string]string{
 				constants.HeaderXForwardedProto: constants.DefaultProto,
 			},
 		},
-		// Instance more smarter >= v2
-		// You can easily extend here with more smart variants
-		// Example:
-		// {
-		//     Name: "Via: 1.1 attacker.example",
-		//     Headers: map[string]string{
-		//         constants.HeaderVia: constants.DefaultViaValue,
-		//     },
-		// },
+	)
+
+	return variants
+}
+
+func loadLines(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
 	}
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines, scanner.Err()
 }

--- a/ck/wordlists/headers.txt
+++ b/ck/wordlists/headers.txt
@@ -1,0 +1,3 @@
+X-Host
+X-Forwarded-Host
+True-Client-IP

--- a/ck/wordlists/params.txt
+++ b/ck/wordlists/params.txt
@@ -1,0 +1,2 @@
+cb=123456
+debug=true


### PR DESCRIPTION
- generate header and query parameter variants from wordlists
- use example.com as the safe default domain
- add initial header and query parameter wordlists